### PR TITLE
Do the minmax over flattened arrays for the contiguous case

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ min_val, max_val = numpy_minmax.minmax(arr)  # 0.0, 1336.0
 * `CC=clang pip install -e .`
 * `pytest`
 
+# Running benchmarks
+* Install diplib `pip install diplib`
+* `python scripts/perf_benchmark.py`
+
 # Acknowledgements
 
 This library is maintained/backed by [Nomono](https://nomono.co/), a Norwegian audio AI startup.

--- a/numpy_minmax/__init__.py
+++ b/numpy_minmax/__init__.py
@@ -10,18 +10,9 @@ __version__ = "0.1.0"
 def minmax(a: NDArray) -> Tuple:
     if 0 in a.shape:
         raise ValueError("Cannot find min/max value in empty array")
-    if a.dtype == np.dtype("float32") and a.flags["C_CONTIGUOUS"]:
-        if a.ndim == 1:
-            result = _numpy_minmax.lib.minmax_1d(
-                _numpy_minmax.ffi.cast("float *", a.ctypes.data),
-                len(a),
-            )
-            return np.float32(result.min_val), np.float32(result.max_val)
-        elif a.ndim == 2:
-            result = _numpy_minmax.lib.minmax_2d(
-                _numpy_minmax.ffi.cast("float *", a.ctypes.data),
-                a.shape[0],
-                a.shape[1],
-            )
-            return np.float32(result.min_val), np.float32(result.max_val)
+    if a.dtype == np.dtype("float32") and (a.flags["C_CONTIGUOUS"] or a.flags["F_CONTIGUOUS"]):
+        result = _numpy_minmax.lib.minmax_contiguous(
+            _numpy_minmax.ffi.cast("float *", a.ctypes.data), a.size
+        )
+        return np.float32(result.min_val), np.float32(result.max_val)
     return np.amin(a), np.amax(a)

--- a/numpy_minmax/_minmax.c
+++ b/numpy_minmax/_minmax.c
@@ -6,7 +6,7 @@ typedef struct {
     float max_val;
 } MinMaxResult;
 
-MinMaxResult minmax_pairwise_1d(float *a, size_t length) {
+MinMaxResult minmax_pairwise(float *a, size_t length) {
     MinMaxResult result;
 
     if (length <= 0) {
@@ -38,7 +38,7 @@ MinMaxResult minmax_pairwise_1d(float *a, size_t length) {
 }
 
 
-MinMaxResult minmax_avx2_1d(float *a, size_t length) {
+MinMaxResult minmax_avx2(float *a, size_t length) {
     MinMaxResult result = { .min_val = FLT_MAX, .max_val = -FLT_MAX };
 
     // Return early for empty arrays
@@ -75,90 +75,10 @@ MinMaxResult minmax_avx2_1d(float *a, size_t length) {
     return result;
 }
 
-MinMaxResult minmax_1d(float *a, size_t length) {
+MinMaxResult minmax_contiguous(float *a, size_t length) {
     if (length >= 16) {
-        return minmax_avx2_1d(a, length);
+        return minmax_avx2(a, length);
     } else {
-        return minmax_pairwise_1d(a, length);
-    }
-}
-
-MinMaxResult minmax_avx2_2d(float *a, size_t shape_0, size_t shape_1) {
-    MinMaxResult result = { .min_val = FLT_MAX, .max_val = -FLT_MAX };
-
-    // Return early for empty arrays
-    if (shape_0 == 0 || shape_1 == 0) {
-        return (MinMaxResult){0.0, 0.0};
-    }
-
-    for (size_t row = 0; row < shape_0; ++row) {
-        size_t i = 0;
-        __m256 min_vals = _mm256_set1_ps(result.min_val);
-        __m256 max_vals = _mm256_set1_ps(result.max_val);
-        float* row_ptr = a + (row * shape_1);
-
-        // Process elements in chunks of eight
-        for (; i <= shape_1 - 8; i += 8) {
-            __m256 vals = _mm256_loadu_ps(&row_ptr[i]);
-            min_vals = _mm256_min_ps(min_vals, vals);
-            max_vals = _mm256_max_ps(max_vals, vals);
-        }
-
-        // Process remainder elements
-        for (; i < shape_1; ++i) {
-            if (row_ptr[i] < result.min_val) result.min_val = row_ptr[i];
-            if (row_ptr[i] > result.max_val) result.max_val = row_ptr[i];
-        }
-
-        // Reduce min and max values from AVX registers
-        float temp_min[8], temp_max[8];
-        _mm256_storeu_ps(temp_min, min_vals);
-        _mm256_storeu_ps(temp_max, max_vals);
-        for (i = 0; i < 8; ++i) {
-            if (temp_min[i] < result.min_val) result.min_val = temp_min[i];
-            if (temp_max[i] > result.max_val) result.max_val = temp_max[i];
-        }
-    }
-
-    return result;
-}
-
-MinMaxResult minmax_pairwise_2d(float *a, size_t shape_0, size_t shape_1) {
-    MinMaxResult result = { .min_val = FLT_MAX, .max_val = -FLT_MAX };
-
-    // Return early for empty arrays
-    if (shape_0 == 0 || shape_1 == 0) {
-        return (MinMaxResult){0.0, 0.0};
-    }
-
-    for (size_t row = 0; row < shape_0; ++row) {
-        size_t i = 0;
-        float* row_ptr = a + (row * shape_1);
-
-        // Initialize min and max for the row. Handle edge case for odd number of elements.
-        if (shape_1 % 2 != 0) {
-            float last_elem = row_ptr[shape_1 - 1];
-            if (last_elem < result.min_val) result.min_val = last_elem;
-            if (last_elem > result.max_val) result.max_val = last_elem;
-        }
-
-        // Process elements in pairs for each row
-        for (; i < shape_1 - 1; i += 2) {
-            float smaller = row_ptr[i] < row_ptr[i + 1] ? row_ptr[i] : row_ptr[i + 1];
-            float larger = row_ptr[i] < row_ptr[i + 1] ? row_ptr[i + 1] : row_ptr[i];
-
-            if (smaller < result.min_val) result.min_val = smaller;
-            if (larger > result.max_val) result.max_val = larger;
-        }
-    }
-
-    return result;
-}
-
-MinMaxResult minmax_2d(float *a, size_t shape_0, size_t shape_1) {
-    if (shape_1 >= 16) {
-        return minmax_avx2_2d(a, shape_0, shape_1);
-    } else {
-        return minmax_pairwise_2d(a, shape_0, shape_1);
+        return minmax_pairwise(a, length);
     }
 }

--- a/numpy_minmax/_minmax_cffi.py
+++ b/numpy_minmax/_minmax_cffi.py
@@ -10,10 +10,7 @@ ffibuilder.cdef("""
     } MinMaxResult;
 """)
 ffibuilder.cdef(
-    "MinMaxResult minmax_1d(float *, size_t);"
-)
-ffibuilder.cdef(
-    "MinMaxResult minmax_2d(float *, size_t, size_t);"
+    "MinMaxResult minmax_contiguous(float *, size_t);"
 )
 
 script_dir = os.path.dirname(os.path.realpath(__file__))

--- a/scripts/perf_benchmark.py
+++ b/scripts/perf_benchmark.py
@@ -5,6 +5,7 @@ import numpy as np
 
 import numpy_minmax
 
+rng = np.random.default_rng()
 
 class timer(object):
     """
@@ -43,7 +44,7 @@ def perf_benchmark_many_small_1d_c_contiguous():
     print("===\nperf_benchmark_many_small_1d_c_contiguous:")
     arrays = []
     for i in range(100_000):
-        a = np.random.uniform(low=-4.0, high=3.9, size=(9,)).astype(np.float32)
+        a = rng.uniform(low=-4.0, high=3.9, size=(9,)).astype(np.float32)
         arrays.append(a)
 
     with timer("numpy.amax and numpy.amin sequentially"):
@@ -64,7 +65,7 @@ def perf_benchmark_many_small_2d_c_contiguous():
     print("===\nperf_benchmark_many_small_2d_c_contiguous:")
     arrays = []
     for i in range(100_000):
-        a = np.random.uniform(low=-4.0, high=3.9, size=(3, 9)).astype(np.float32)
+        a = rng.uniform(low=-4.0, high=3.9, size=(3, 9)).astype(np.float32)
         arrays.append(a)
 
     with timer("numpy.amax and numpy.amin sequentially"):
@@ -83,7 +84,7 @@ def perf_benchmark_many_small_2d_c_contiguous():
 
 def perf_benchmark_large_1d_c_contiguous():
     print("===\nperf_benchmark_large_1d_c_contiguous:")
-    a = np.random.uniform(low=-4.0, high=3.9, size=(999_999_999,)).astype(np.float32)
+    a = rng.uniform(low=-4.0, high=3.9, size=(999_999_999,)).astype(np.float32)
 
     with timer("numpy.amax and numpy.amin sequentially"):
         min_val = np.amin(a)
@@ -106,7 +107,7 @@ def perf_benchmark_large_1d_c_contiguous():
 
 def perf_benchmark_large_2d_c_contiguous():
     print("===\nperf_benchmark_large_2d_c_contiguous:")
-    a = np.random.uniform(low=-4.0, high=3.9, size=(2, 999_999_999)).astype(np.float32)
+    a = rng.random(size=(2, 999_999_999), dtype=np.float32)
 
     with timer("numpy.amax and numpy.amin sequentially"):
         min_val = np.amin(a)
@@ -127,10 +128,33 @@ def perf_benchmark_large_2d_c_contiguous():
     print(f"===\nnumpy-minmax median: {np.median(times):.3f}")
 
 
+def perf_benchmark_large_2d_f_contiguous():
+    print("===\nperf_benchmark_large_2d_f_contiguous:")
+    a = rng.random(size=(2, 999_999_999), dtype=np.float32)
+    a = np.asfortranarray(a)
+
+    with timer("numpy.amax and numpy.amin sequentially"):
+        min_val = np.amin(a)
+        max_val = np.amax(a)
+        print(min_val, max_val)
+
+    with timer("diplib"):
+        min_val, max_val = dip.MaximumAndMinimum(a)
+        print(min_val, max_val, "diplib")
+
+    times = []
+    for i in range(5):
+        with timer("minmax") as t:
+            min_val, max_val = numpy_minmax.minmax(a)
+            print(min_val, max_val)
+        times.append(t.execution_time)
+
+    print(f"===\nnumpy-minmax median: {np.median(times):.3f}")
+
 def perf_benchmark_large_1d_not_c_contiguous():
     print("===\nperf_benchmark_large_1d_not_c_contiguous:")
     a = np.flip(
-        np.random.uniform(low=-4.0, high=3.9, size=(999_999_999,)).astype(np.float32)
+        rng.uniform(low=-4.0, high=3.9, size=(999_999_999,)).astype(np.float32)
     )
 
     with timer("numpy.amax and numpy.amin sequentially"):
@@ -155,7 +179,7 @@ def perf_benchmark_large_1d_not_c_contiguous():
 def perf_benchmark_large_2d_not_c_contiguous():
     print("===\nperf_benchmark_large_2d_not_c_contiguous:")
     a = np.flip(
-        np.random.uniform(low=-4.0, high=3.9, size=(2, 999_999_999)).astype(np.float32)
+        rng.random(size=(2, 299_999_999), dtype=np.float32)
     )
 
     times = []
@@ -183,4 +207,5 @@ if __name__ == "__main__":
     perf_benchmark_large_1d_c_contiguous()
     perf_benchmark_large_1d_not_c_contiguous()
     perf_benchmark_large_2d_c_contiguous()
-    perf_benchmark_large_1d_not_c_contiguous()
+    perf_benchmark_large_2d_f_contiguous()
+    perf_benchmark_large_2d_not_c_contiguous()

--- a/tests/test_minmax.py
+++ b/tests/test_minmax.py
@@ -78,6 +78,17 @@ class TestMinMax:
         assert min_val == np.amin(arr)
         assert max_val == np.amax(arr)
 
+    def test_minmax_unaligned(self):
+        # Allocate memory and create an unaligned array from that
+        buf = np.arange(402, dtype=np.uint8)
+        arr = np.frombuffer(buf.data, offset=2, count=100, dtype=np.float32)
+        arr.shape = 10, 10
+        assert arr.flags["ALIGNED"] == False
+
+        min_val, max_val = numpy_minmax.minmax(arr)
+        assert min_val == np.amin(arr)
+        assert max_val == np.amax(arr)
+
     def test_minmax_3d_shape(self):
         arr = np.random.uniform(low=-6.0, high=3.0, size=(2, 2, 16)).astype(np.float32)
         min_val, max_val = numpy_minmax.minmax(arr)

--- a/tests/test_minmax.py
+++ b/tests/test_minmax.py
@@ -71,6 +71,13 @@ class TestMinMax:
         assert min_val == np.amin(arr)
         assert max_val == np.amax(arr)
 
+    def test_minimax_2d_f_contiguous(self):
+        arr = np.random.uniform(low=-6.0, high=3.0, size=(2, 27)).astype(np.float32)
+        arr = np.asfortranarray(arr)
+        min_val, max_val = numpy_minmax.minmax(arr)
+        assert min_val == np.amin(arr)
+        assert max_val == np.amax(arr)
+
     def test_minmax_3d_shape(self):
         arr = np.random.uniform(low=-6.0, high=3.0, size=(2, 2, 16)).astype(np.float32)
         min_val, max_val = numpy_minmax.minmax(arr)


### PR DESCRIPTION
This reduces the amount of code, and is maybe a tiny amount faster.

Also updated the benchmarks and the tests