### PR TITLE
Optimized processing for 1d strided arrays

### DIFF
--- a/numpy_minmax/__init__.py
+++ b/numpy_minmax/__init__.py
@@ -20,11 +20,9 @@ def minmax(a: NDArray) -> Tuple:
             )
             return np.float32(result.min_val), np.float32(result.max_val)
         if a.ndim == 1:
-            result = _numpy_minmax.lib.minmax_1d(
+            result = _numpy_minmax.lib.minmax_1d_strided(
                 _numpy_minmax.ffi.cast("float *", a.ctypes.data), a.size, a.strides[0]
             )
             return np.float32(result.min_val), np.float32(result.max_val)
-       strides = np.array(a.strides)
-       min_stride = np.amin(np.strides)
-       if np.all(strides % min_stride == 0):
+       # TODO: Find multi-dim arrays that can be simplified to a single stride
     return np.amin(a), np.amax(a)

--- a/numpy_minmax/__init__.py
+++ b/numpy_minmax/__init__.py
@@ -13,9 +13,18 @@ except ImportError:
 def minmax(a: NDArray) -> Tuple:
     if 0 in a.shape:
         raise ValueError("Cannot find min/max value in empty array")
-    if a.dtype == np.dtype("float32") and (a.flags["C_CONTIGUOUS"] or a.flags["F_CONTIGUOUS"]):
-        result = _numpy_minmax.lib.minmax_contiguous(
-            _numpy_minmax.ffi.cast("float *", a.ctypes.data), a.size
-        )
-        return np.float32(result.min_val), np.float32(result.max_val)
+    if a.dtype == np.dtype("float32"):
+        if (a.flags["C_CONTIGUOUS"] or a.flags["F_CONTIGUOUS"]):
+            result = _numpy_minmax.lib.minmax_contiguous(
+                _numpy_minmax.ffi.cast("float *", a.ctypes.data), a.size
+            )
+            return np.float32(result.min_val), np.float32(result.max_val)
+        if a.ndim == 1:
+            result = _numpy_minmax.lib.minmax_1d(
+                _numpy_minmax.ffi.cast("float *", a.ctypes.data), a.size, a.strides[0]
+            )
+            return np.float32(result.min_val), np.float32(result.max_val)
+       strides = np.array(a.strides)
+       min_stride = np.amin(np.strides)
+       if np.all(strides % min_stride == 0):
     return np.amin(a), np.amax(a)

--- a/numpy_minmax/_minmax.c
+++ b/numpy_minmax/_minmax.c
@@ -1,6 +1,15 @@
 #include <immintrin.h>
 #include <float.h>
 
+#define REDUCE_RESULT_FROM_MM256(min_vals, max_vals, result) ({\
+    float temp_min[8], temp_max[8]; \
+    _mm256_storeu_ps(temp_min, min_vals); \
+    _mm256_storeu_ps(temp_max, max_vals); \
+    for (i = 0; i < 8; ++i) { \
+        if (temp_min[i] < result.min_val) result.min_val = temp_min[i]; \
+        if (temp_max[i] > result.max_val) result.max_val = temp_max[i]; \
+}})
+
 typedef struct {
     float min_val;
     float max_val;
@@ -8,13 +17,6 @@ typedef struct {
 
 MinMaxResult minmax_pairwise(float *a, size_t length) {
     MinMaxResult result;
-
-    if (length <= 0) {
-        // Handle the case where the array is empty or length is invalid
-        result.min_val = 0.0;
-        result.max_val = 0.0;
-        return result;
-    }
 
     // Initialize min and max with the last element of the array.
     // This ensures that it works correctly for odd length arrays as well as even.
@@ -38,21 +40,16 @@ MinMaxResult minmax_pairwise(float *a, size_t length) {
 }
 
 
-MinMaxResult minmax_avx2(float *a, size_t length) {
+MinMaxResult minmax_avx(float *a, size_t length) {
     MinMaxResult result = { .min_val = FLT_MAX, .max_val = -FLT_MAX };
 
-    // Return early for empty arrays
-    if (length == 0) {
-        return (MinMaxResult){0.0, 0.0};
-    }
-
-    __m256 min_vals = _mm256_set1_ps(result.min_val);
-    __m256 max_vals = _mm256_set1_ps(result.max_val);
+    __m256 min_vals = _mm256_loadu_ps(a);
+    __m256 max_vals = min_vals;
 
     // Process elements in chunks of eight
-    size_t i = 0;
+    size_t i = 8;
     for (; i <= length - 8; i += 8) {
-        __m256 vals = _mm256_loadu_ps(&a[i]);
+        __m256 vals = _mm256_loadu_ps(a + i);
         min_vals = _mm256_min_ps(min_vals, vals);
         max_vals = _mm256_max_ps(max_vals, vals);
     }
@@ -63,22 +60,109 @@ MinMaxResult minmax_avx2(float *a, size_t length) {
         if (a[i] > result.max_val) result.max_val = a[i];
     }
 
-    // Reduce min and max values from AVX registers
-    float temp_min[8], temp_max[8];
-    _mm256_storeu_ps(temp_min, min_vals);
-    _mm256_storeu_ps(temp_max, max_vals);
-    for (i = 0; i < 8; ++i) {
-        if (temp_min[i] < result.min_val) result.min_val = temp_min[i];
-        if (temp_max[i] > result.max_val) result.max_val = temp_max[i];
-    }
+    REDUCE_RESULT_FROM_MM256(min_vals, max_vals, result);
 
     return result;
 }
 
 MinMaxResult minmax_contiguous(float *a, size_t length) {
+    // Return early for empty arrays
+    if (length == 0) {
+        return (MinMaxResult){0.0, 0.0};
+    }
     if (length >= 16) {
-        return minmax_avx2(a, length);
+        return minmax_avx(a, length);
     } else {
         return minmax_pairwise(a, length);
     }
+}
+
+MinMaxResult minmax_pairwise_strided(char *a, size_t length, long stride) {
+    MinMaxResult result;
+
+    // Initialize min and max with the last element of the array.
+    // This ensures that it works correctly for odd length arrays as well as even.
+    result.min_val = *(float*)(a + (length -1)*stride);
+    result.max_val = result.min_val;
+
+    // Process elements in pairs
+    float smaller;
+    float larger;
+    for (size_t i = 0; i < (length - 1)*stride; i += 2*stride) {
+        if (*(float*)(a + i) < *(float*)(a + i + stride)) {
+            smaller = *(float*)(a + i);
+            larger = *(float*)(a + i + stride);
+        } else {
+            smaller = *(float*)(a + i + stride);
+            larger = *(float*)(a + i);
+        }
+
+        if (smaller < result.min_val) {
+            result.min_val = smaller;
+        }
+        if (larger > result.max_val) {
+            result.max_val = larger;
+        }
+    }
+    return result;
+}
+
+MinMaxResult minmax_avx_strided(char *a, size_t length, long stride) {
+    MinMaxResult result = { .min_val = FLT_MAX, .max_val = -FLT_MAX };
+
+    __m256 min_vals = _mm256_set_ps(
+        *(float*)(a),
+        *(float*)(a + stride),
+        *(float*)(a + 2*stride),
+        *(float*)(a + 3*stride),
+        *(float*)(a + 4*stride),
+        *(float*)(a + 5*stride),
+        *(float*)(a + 6*stride),
+        *(float*)(a + 7*stride)
+        );
+    __m256 max_vals = min_vals;
+
+    // Process elements in chunks of eight
+    size_t i = 8*stride;
+    for (; i <= (length - 8)*stride; i += 8*stride) {
+        __m256 vals = _mm256_set_ps(
+            *(float*)(a + i),
+            *(float*)(a + i + stride),
+            *(float*)(a + i + 2*stride),
+            *(float*)(a + i + 3*stride),
+            *(float*)(a + i + 4*stride),
+            *(float*)(a + i + 5*stride),
+            *(float*)(a + i + 6*stride),
+            *(float*)(a + i + 7*stride)
+            );
+        min_vals = _mm256_min_ps(min_vals, vals);
+        max_vals = _mm256_max_ps(max_vals, vals);
+    }
+
+    // Process remainder elements
+    for (; i < length*stride; i+=stride) {
+        if (*(float*)(a + i) < result.min_val) result.min_val = *(float*)(a + i);
+        if (*(float*)(a + i) > result.max_val) result.max_val = *(float*)(a + i);
+    }
+
+    REDUCE_RESULT_FROM_MM256(min_vals, max_vals, result);
+
+    return result;
+}
+
+
+MinMaxResult minmax_1d(float *a, size_t length, long stride) {
+    // Return early for empty arrays
+    if (length == 0) {
+        return (MinMaxResult){0.0, 0.0};
+    }
+    if (stride < 0){
+        if (-stride == sizeof(float)){
+            return minmax_contiguous(a - length + 1, length);
+        }
+        char* a_bytes = (char*)a;
+        minmax_avx_strided(a_bytes + (length)*stride, length-2, -stride);
+    }
+    // return minmax_pairwise_strided(a, length, stride/sizeof(float));
+    return minmax_avx_strided((char*)a, length, stride);
 }

--- a/numpy_minmax/_minmax_cffi.py
+++ b/numpy_minmax/_minmax_cffi.py
@@ -13,7 +13,7 @@ ffibuilder.cdef(
     "MinMaxResult minmax_contiguous(float *, size_t);"
 )
 ffibuilder.cdef(
-    "MinMaxResult minmax_1d(float *, size_t, long);"
+    "MinMaxResult minmax_1d_strided(float *, size_t, long);"
 )
 
 script_dir = os.path.dirname(os.path.realpath(__file__))

--- a/numpy_minmax/_minmax_cffi.py
+++ b/numpy_minmax/_minmax_cffi.py
@@ -12,6 +12,9 @@ ffibuilder.cdef("""
 ffibuilder.cdef(
     "MinMaxResult minmax_contiguous(float *, size_t);"
 )
+ffibuilder.cdef(
+    "MinMaxResult minmax_1d(float *, size_t, long);"
+)
 
 script_dir = os.path.dirname(os.path.realpath(__file__))
 c_file_path = os.path.join(script_dir, "_minmax.c")

--- a/scripts/perf_benchmark.py
+++ b/scripts/perf_benchmark.py
@@ -153,9 +153,11 @@ def perf_benchmark_large_2d_f_contiguous():
 
 def perf_benchmark_large_1d_not_c_contiguous():
     print("===\nperf_benchmark_large_1d_not_c_contiguous:")
-    a = np.flip(
-        rng.uniform(low=-4.0, high=3.9, size=(999_999_999,)).astype(np.float32)
-    )
+   # a = np.flip(
+   #     rng.uniform(low=-4.0, high=3.9, size=(999_999_999,)).astype(np.float32)
+   # )
+    a = rng.uniform(low=-4.0, high=3.9, size=(999_999_999,)).astype(np.float32)[::5]
+    print(a.strides)
 
     with timer("numpy.amax and numpy.amin sequentially"):
         min_val = np.amin(a)
@@ -169,7 +171,7 @@ def perf_benchmark_large_1d_not_c_contiguous():
     times = []
     for i in range(5):
         with timer("minmax") as t:
-            min_val, max_val = numpy_minmax.minmax(np.ascontiguousarray(a))
+            min_val, max_val = numpy_minmax.minmax(a)
             print(min_val, max_val)
         times.append(t.execution_time)
 

--- a/scripts/perf_benchmark.py
+++ b/scripts/perf_benchmark.py
@@ -107,7 +107,7 @@ def perf_benchmark_large_1d_c_contiguous():
 
 def perf_benchmark_large_2d_c_contiguous():
     print("===\nperf_benchmark_large_2d_c_contiguous:")
-    a = rng.random(size=(2, 999_999_999), dtype=np.float32)
+    a = rng.random(size=(2, 499_999_999), dtype=np.float32)
 
     with timer("numpy.amax and numpy.amin sequentially"):
         min_val = np.amin(a)
@@ -130,7 +130,7 @@ def perf_benchmark_large_2d_c_contiguous():
 
 def perf_benchmark_large_2d_f_contiguous():
     print("===\nperf_benchmark_large_2d_f_contiguous:")
-    a = rng.random(size=(2, 999_999_999), dtype=np.float32)
+    a = rng.random(size=(2, 499_999_999), dtype=np.float32)
     a = np.asfortranarray(a)
 
     with timer("numpy.amax and numpy.amin sequentially"):
@@ -153,11 +153,32 @@ def perf_benchmark_large_2d_f_contiguous():
 
 def perf_benchmark_large_1d_not_c_contiguous():
     print("===\nperf_benchmark_large_1d_not_c_contiguous:")
-   # a = np.flip(
-   #     rng.uniform(low=-4.0, high=3.9, size=(999_999_999,)).astype(np.float32)
-   # )
-    a = rng.uniform(low=-4.0, high=3.9, size=(999_999_999,)).astype(np.float32)[::5]
-    print(a.strides)
+    a = rng.uniform(low=-4.0, high=3.9, size=(499_999_999,)).astype(np.float32)[::5]
+
+    with timer("numpy.amax and numpy.amin sequentially"):
+        min_val = np.amin(a)
+        max_val = np.amax(a)
+        print(min_val, max_val)
+
+    with timer("diplib"):
+        min_val, max_val = dip.MaximumAndMinimum(a)
+        print(min_val, max_val, "diplib")
+
+    times = []
+    for i in range(5):
+        with timer("minmax") as t:
+            min_val, max_val = numpy_minmax.minmax(a)
+            print(min_val, max_val)
+        times.append(t.execution_time)
+
+    print(f"===\nnumpy-minmax median: {np.median(times):.3f}")
+
+
+def perf_benchmark_large_1d_flipped():
+    print("===\nperf_benchmark_large_1d_flipped:")
+    a = np.flip(
+        rng.uniform(low=-4.0, high=3.9, size=(499_999_999,)).astype(np.float32)
+    )
 
     with timer("numpy.amax and numpy.amin sequentially"):
         min_val = np.amin(a)
@@ -184,15 +205,6 @@ def perf_benchmark_large_2d_not_c_contiguous():
         rng.random(size=(2, 299_999_999), dtype=np.float32)
     )
 
-    times = []
-    for i in range(5):
-        with timer("minmax") as t:
-            min_val, max_val = numpy_minmax.minmax(np.ascontiguousarray(a))
-            print(min_val, max_val)
-        times.append(t.execution_time)
-
-    print(f"===\nnumpy-minmax median: {np.median(times):.3f}")
-
     with timer("numpy.amax and numpy.amin sequentially"):
         min_val = np.amin(a)
         max_val = np.amax(a)
@@ -202,11 +214,21 @@ def perf_benchmark_large_2d_not_c_contiguous():
         min_val, max_val = dip.MaximumAndMinimum(a)
         print(min_val, max_val, "diplib")
 
+    times = []
+    for i in range(5):
+        with timer("minmax") as t:
+            min_val, max_val = numpy_minmax.minmax(np.ascontiguousarray(a))
+            print(min_val, max_val)
+        times.append(t.execution_time)
+
+    print(f"===\nnumpy-minmax median: {np.median(times):.3f}")
+
 
 if __name__ == "__main__":
     perf_benchmark_many_small_1d_c_contiguous()
     perf_benchmark_many_small_2d_c_contiguous()
     perf_benchmark_large_1d_c_contiguous()
+    perf_benchmark_large_1d_flipped()
     perf_benchmark_large_1d_not_c_contiguous()
     perf_benchmark_large_2d_c_contiguous()
     perf_benchmark_large_2d_f_contiguous()

--- a/tests/test_minmax.py
+++ b/tests/test_minmax.py
@@ -78,6 +78,19 @@ class TestMinMax:
         assert min_val == np.amin(arr)
         assert max_val == np.amax(arr)
 
+    def test_minimax_1d_non_contiguous(self):
+        arr = np.random.uniform(low=-6.0, high=3.0, size=(27,)).astype(np.float32)[::2]
+        min_val, max_val = numpy_minmax.minmax(arr)
+        assert min_val == np.amin(arr)
+        assert max_val == np.amax(arr)
+
+    def test_minimax_1d_non_contiguous_negative_stride(self):
+        arr = np.random.uniform(low=-6.0, high=3.0, size=(27,)).astype(np.float32)[::-1]
+        print(arr.strides)
+        min_val, max_val = numpy_minmax.minmax(arr)
+        assert min_val == np.amin(arr)
+        assert max_val == np.amax(arr)
+
     def test_minmax_unaligned(self):
         # Allocate memory and create an unaligned array from that
         buf = np.arange(402, dtype=np.uint8)

--- a/tests/test_minmax.py
+++ b/tests/test_minmax.py
@@ -78,15 +78,32 @@ class TestMinMax:
         assert min_val == np.amin(arr)
         assert max_val == np.amax(arr)
 
+    def test_minimax_1d_non_contiguous_short(self):
+        arr = np.random.uniform(low=-6.0, high=3.0, size=(27,)).astype(np.float32)[::3]
+        min_val, max_val = numpy_minmax.minmax(arr)
+        assert min_val == np.amin(arr)
+        assert max_val == np.amax(arr)
+
     def test_minimax_1d_non_contiguous(self):
         arr = np.random.uniform(low=-6.0, high=3.0, size=(27,)).astype(np.float32)[::2]
         min_val, max_val = numpy_minmax.minmax(arr)
         assert min_val == np.amin(arr)
         assert max_val == np.amax(arr)
 
-    def test_minimax_1d_non_contiguous_negative_stride(self):
+    def test_minimax_1d_negative_stride(self):
         arr = np.random.uniform(low=-6.0, high=3.0, size=(27,)).astype(np.float32)[::-1]
-        print(arr.strides)
+        min_val, max_val = numpy_minmax.minmax(arr)
+        assert min_val == np.amin(arr)
+        assert max_val == np.amax(arr)
+
+    def test_minimax_1d_non_contiguous_negative_stride(self):
+        arr = np.random.uniform(low=-6.0, high=3.0, size=(61,)).astype(np.float32)[::-2]
+        min_val, max_val = numpy_minmax.minmax(arr)
+        assert min_val == np.amin(arr)
+        assert max_val == np.amax(arr)
+
+    def test_minimax_1d_non_contiguous_negative_stride_short(self):
+        arr = np.random.uniform(low=-6.0, high=3.0, size=(27,)).astype(np.float32)[::-3]
         min_val, max_val = numpy_minmax.minmax(arr)
         assert min_val == np.amin(arr)
         assert max_val == np.amax(arr)


### PR DESCRIPTION
With some processing of the strides this should be possible to expand to higher dimensional arrays that can be simplified down to 1 stride, but currently only support 1d arrays.

Diplib is still faster for the not just flipped case, but that is because they do multithreading (hardcoded, so we can't disable for testing)