### PR TITLE
Add support for AVX512

### DIFF
--- a/numpy_minmax/_minmax.c
+++ b/numpy_minmax/_minmax.c
@@ -17,7 +17,7 @@ bool system_supports_avx512() {
     __cpuid_count(7, 0, eax, ebx, ecx, edx);
 
     // Check the AVX512F bit (bit 16 of EBX)
-    return (ebx & (1 << 16)) != 0;
+    return (ebx & bit_AVX512F) != 0;
 }
 
 static inline MinMaxResult minmax_pairwise(const float *a, size_t length) {

--- a/numpy_minmax/_minmax_cffi.py
+++ b/numpy_minmax/_minmax_cffi.py
@@ -9,12 +9,8 @@ ffibuilder.cdef("""
         float max_val;
     } MinMaxResult;
 """)
-ffibuilder.cdef(
-    "MinMaxResult minmax_contiguous(float *, size_t);"
-)
-ffibuilder.cdef(
-    "MinMaxResult minmax_1d_strided(float *, size_t, long);"
-)
+ffibuilder.cdef("MinMaxResult minmax_contiguous(float *, size_t);")
+ffibuilder.cdef("MinMaxResult minmax_1d_strided(float *, size_t, long);")
 
 script_dir = os.path.dirname(os.path.realpath(__file__))
 c_file_path = os.path.join(script_dir, "_minmax.c")
@@ -22,13 +18,11 @@ c_file_path = os.path.join(script_dir, "_minmax.c")
 with open(c_file_path, "r") as file:
     c_code = file.read()
 
-extra_compile_args = ["-mavx", "-O3", "-Wall"]
+extra_compile_args = ["-mavx", "-mavx512f", "-O3", "-Wall"]
 if os.name == "posix":
     extra_compile_args.append("-Wextra")
 
-ffibuilder.set_source(
-    "_numpy_minmax", c_code, extra_compile_args=extra_compile_args
-)
+ffibuilder.set_source("_numpy_minmax", c_code, extra_compile_args=extra_compile_args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This seems to make it ~14% faster on a Intel i7 11700K with AVX-512.

It runs with the same exec time as before on an older Intel CPU without AVX-512.

I haven't made an AVX512-equivalent of minmax_avx_strided yet

https://github.com/nomonosound/numpy-minmax/issues/2