### PR TITLE
Use msvc-compatible cpuid instruction. Switch from gcc to clang on Linux because perf.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
         env:
           CIBW_ARCHS: "auto64"
           CIBW_SKIP: "cp36-* cp37-* pp37-* pp310-*"
+          CC: clang
         run: |
           python -m cibuildwheel --output-dir wheelhouse
       - name: Save Wheels

--- a/numpy_minmax/_minmax.c
+++ b/numpy_minmax/_minmax.c
@@ -1,7 +1,16 @@
-#include <cpuid.h>
 #include <float.h>
 #include <immintrin.h>
 #include <stdbool.h>
+
+#ifdef _MSC_VER
+    #include <intrin.h>  // MSVC
+#else
+    #include <cpuid.h>  // GCC and Clang
+#endif
+
+#ifndef bit_AVX512F
+#define bit_AVX512F     (1 << 16)
+#endif
 
 typedef struct {
     float min_val;
@@ -14,9 +23,17 @@ bool system_supports_avx512() {
     unsigned int eax, ebx, ecx, edx;
 
     // EAX=7, ECX=0: Extended Features
-    __cpuid_count(7, 0, eax, ebx, ecx, edx);
+    #ifdef _MSC_VER
+        // MSVC
+        int cpuInfo[4];
+        __cpuid(cpuInfo, 7);
+        ebx = cpuInfo[1];
+    #else
+        // GCC, Clang
+        __cpuid(7, eax, ebx, ecx, edx);
+    #endif
 
-    // Check the AVX512F bit (bit 16 of EBX)
+    // Check the AVX512F bit in EBX
     return (ebx & bit_AVX512F) != 0;
 }
 


### PR DESCRIPTION
The joys of compiler differences 🤓 

Close https://github.com/nomonosound/numpy-minmax/issues/22