### PR TITLE
Optimize int16 processing

### DIFF
--- a/numpy_minmax/__init__.py
+++ b/numpy_minmax/__init__.py
@@ -14,7 +14,7 @@ def minmax(a: NDArray) -> Tuple:
     if 0 in a.shape:
         raise ValueError("Cannot find min/max value in empty array")
     if a.dtype == np.dtype("float32"):
-        if (a.flags["C_CONTIGUOUS"] or a.flags["F_CONTIGUOUS"]):
+        if a.flags["C_CONTIGUOUS"] or a.flags["F_CONTIGUOUS"]:
             result = _numpy_minmax.lib.minmax_contiguous_float32(
                 _numpy_minmax.ffi.cast("float *", a.ctypes.data), a.size
             )
@@ -24,5 +24,13 @@ def minmax(a: NDArray) -> Tuple:
                 _numpy_minmax.ffi.cast("float *", a.ctypes.data), a.size, a.strides[0]
             )
             return np.float32(result.min_val), np.float32(result.max_val)
-       # TODO: Find multi-dim arrays that can be simplified to a single stride
+        # TODO: Find multi-dim arrays that can be simplified to a single stride
+    elif a.dtype == np.dtype("int16") and (
+        a.flags["C_CONTIGUOUS"] or a.flags["F_CONTIGUOUS"]
+    ):
+        result = _numpy_minmax.lib.minmax_contiguous_int16(
+            _numpy_minmax.ffi.cast("int16_t *", a.ctypes.data), a.size
+        )
+        return np.int16(result.min_val), np.int16(result.max_val)
+
     return np.amin(a), np.amax(a)

--- a/numpy_minmax/_minmax_cffi.py
+++ b/numpy_minmax/_minmax_cffi.py
@@ -5,10 +5,17 @@ from cffi import FFI
 ffibuilder = FFI()
 ffibuilder.cdef("""
     typedef struct {
+        int16_t min_val;
+        int16_t max_val;
+    } minmax_result_int16;
+""")
+ffibuilder.cdef("""
+    typedef struct {
         float min_val;
         float max_val;
     } minmax_result_float32;
 """)
+ffibuilder.cdef("minmax_result_int16 minmax_contiguous_int16(int16_t *, size_t);")
 ffibuilder.cdef("minmax_result_float32 minmax_contiguous_float32(float *, size_t);")
 ffibuilder.cdef("minmax_result_float32 minmax_1d_strided_float32(float *, size_t, long);")
 

--- a/tests/test_minmax.py
+++ b/tests/test_minmax.py
@@ -4,157 +4,212 @@ import pytest
 import numpy_minmax
 
 
-class TestMinMax:
-    def test_minmax_even(self):
-        arr = np.array([0.0, 1.0, -2.0, 0.0], dtype=np.float32)
-        min_val, max_val = numpy_minmax.minmax(arr)
-        assert min_val == -2.0
-        assert max_val == 1.0
-        assert isinstance(min_val, np.float32)
-        assert isinstance(max_val, np.float32)
+@pytest.mark.parametrize("dtype", [np.float32, np.int16])
+def test_minmax_even(dtype):
+    arr = np.array([0, 1, -2, 0], dtype=dtype)
+    min_val, max_val = numpy_minmax.minmax(arr)
+    assert min_val == -2
+    assert max_val == 1
+    assert isinstance(min_val, dtype)
+    assert isinstance(max_val, dtype)
 
-    def test_minmax_odd(self):
-        arr = np.array([1.0, -2.0, -5.0], dtype=np.float32)
-        min_val, max_val = numpy_minmax.minmax(arr)
-        assert min_val == -5.0
-        assert max_val == 1.0
 
-    def test_minmax_single_item(self):
-        arr = np.array([1337.0], dtype=np.float32)
-        min_val, max_val = numpy_minmax.minmax(arr)
-        assert min_val == 1337.0
-        assert max_val == 1337.0
+@pytest.mark.parametrize("dtype", [np.float32, np.int16])
+def test_minmax_odd(dtype):
+    arr = np.array([1, -2, -5], dtype=dtype)
+    min_val, max_val = numpy_minmax.minmax(arr)
+    assert min_val == -5
+    assert max_val == 1
 
-    def test_minmax_thirteen_min_value_first(self):
-        arr = np.arange(13, dtype=np.float32)
-        min_val, max_val = numpy_minmax.minmax(arr)
-        assert min_val == 0.0
-        assert max_val == 12.0
 
-    def test_minmax_thirteen_min_value_last_and_not_contiguous(self):
-        arr = np.flip(np.arange(13, dtype=np.float32))
-        min_val, max_val = numpy_minmax.minmax(arr)
-        assert min_val == 0.0
-        assert max_val == 12.0
+@pytest.mark.parametrize("dtype", [np.float32, np.int16])
+def test_minmax_single_item(dtype):
+    arr = np.array([1337], dtype=dtype)
+    min_val, max_val = numpy_minmax.minmax(arr)
+    assert min_val == 1337
+    assert max_val == 1337
 
-    def test_minmax_999_values(self):
-        arr = np.arange(999, dtype=np.float32)
-        min_val, max_val = numpy_minmax.minmax(arr)
-        assert min_val == 0.0
-        assert max_val == 998.0
-        assert isinstance(min_val, np.float32)
-        assert isinstance(max_val, np.float32)
 
-    def test_minmax_999_positive_values(self):
-        arr = np.arange(999, dtype=np.float32) + 5.0
-        min_val, max_val = numpy_minmax.minmax(arr)
-        assert min_val == 5.0
-        assert max_val == 998.0 + 5.0
-        assert isinstance(min_val, np.float32)
-        assert isinstance(max_val, np.float32)
+@pytest.mark.parametrize("dtype", [np.float32, np.int16])
+def test_minmax_thirteen_min_value_first(dtype):
+    arr = np.arange(13, dtype=dtype)
+    min_val, max_val = numpy_minmax.minmax(arr)
+    assert min_val == 0
+    assert max_val == 12
 
-    def test_minmax_4_positive_values(self):
-        arr = np.arange(4, dtype=np.float32) + 5.0
-        min_val, max_val = numpy_minmax.minmax(arr)
-        assert min_val == 5.0
-        assert max_val == 3.0 + 5.0
-        assert isinstance(min_val, np.float32)
-        assert isinstance(max_val, np.float32)
 
-    def test_minmax_float64_numpy_fallback(self):
-        arr = np.arange(17, dtype=np.float64)
-        min_val, max_val = numpy_minmax.minmax(arr)
-        assert min_val == 0.0
-        assert max_val == 16.0
-        assert isinstance(min_val, np.float64)
-        assert isinstance(max_val, np.float64)
+@pytest.mark.parametrize("dtype", [np.float32, np.int16])
+def test_minmax_thirteen_min_value_last_and_not_contiguous(dtype):
+    arr = np.flip(np.arange(13, dtype=dtype))
+    min_val, max_val = numpy_minmax.minmax(arr)
+    assert min_val == 0
+    assert max_val == 12
 
-    def test_minmax_2d_small1(self):
-        arr = np.random.uniform(low=-6.0, high=3.0, size=(15, 2)).astype(np.float32)
-        min_val, max_val = numpy_minmax.minmax(arr)
-        assert min_val == np.amin(arr)
-        assert max_val == np.amax(arr)
 
-    def test_minmax_2d_small2(self):
-        arr = np.random.uniform(low=-6.0, high=3.0, size=(2, 15)).astype(np.float32)
-        min_val, max_val = numpy_minmax.minmax(arr)
-        assert min_val == np.amin(arr)
-        assert max_val == np.amax(arr)
+@pytest.mark.parametrize("dtype", [np.float32, np.int16])
+def test_minmax_999_values(dtype):
+    arr = np.arange(999, dtype=dtype)
+    min_val, max_val = numpy_minmax.minmax(arr)
+    assert min_val == 0
+    assert max_val == 998
+    assert isinstance(min_val, dtype)
+    assert isinstance(max_val, dtype)
 
-    def test_minmax_2d_shape_large(self):
-        arr = np.random.uniform(low=-6.0, high=3.0, size=(2, 999)).astype(np.float32)
-        min_val, max_val = numpy_minmax.minmax(arr)
-        assert min_val == np.amin(arr)
-        assert max_val == np.amax(arr)
 
-    def test_minimax_2d_f_contiguous(self):
-        arr = np.random.uniform(low=-6.0, high=3.0, size=(2, 27)).astype(np.float32)
-        arr = np.asfortranarray(arr)
-        min_val, max_val = numpy_minmax.minmax(arr)
-        assert min_val == np.amin(arr)
-        assert max_val == np.amax(arr)
+@pytest.mark.parametrize("dtype", [np.float32, np.int16])
+def test_minmax_999_positive_values(dtype):
+    offset = 5
+    arr = np.arange(999, dtype=dtype) + offset
+    min_val, max_val = numpy_minmax.minmax(arr)
+    assert min_val == offset
+    assert max_val == 998 + offset
+    assert isinstance(min_val, dtype)
+    assert isinstance(max_val, dtype)
 
-    def test_minimax_1d_non_contiguous_short(self):
-        arr = np.random.uniform(low=-6.0, high=3.0, size=(27,)).astype(np.float32)[::3]
-        min_val, max_val = numpy_minmax.minmax(arr)
-        assert min_val == np.amin(arr)
-        assert max_val == np.amax(arr)
 
-    def test_minimax_1d_non_contiguous(self):
-        arr = np.random.uniform(low=-6.0, high=3.0, size=(27,)).astype(np.float32)[::2]
-        min_val, max_val = numpy_minmax.minmax(arr)
-        assert min_val == np.amin(arr)
-        assert max_val == np.amax(arr)
+@pytest.mark.parametrize("dtype", [np.float32, np.int16])
+def test_minmax_4_positive_values(dtype):
+    offset = 5
+    arr = np.arange(4, dtype=dtype) + offset
+    min_val, max_val = numpy_minmax.minmax(arr)
+    assert min_val == offset
+    assert max_val == 3 + offset
+    assert isinstance(min_val, dtype)
+    assert isinstance(max_val, dtype)
 
-    def test_minimax_1d_negative_stride(self):
-        arr = np.random.uniform(low=-6.0, high=3.0, size=(27,)).astype(np.float32)[::-1]
-        min_val, max_val = numpy_minmax.minmax(arr)
-        assert min_val == np.amin(arr)
-        assert max_val == np.amax(arr)
 
-    def test_minimax_1d_non_contiguous_negative_stride(self):
-        arr = np.random.uniform(low=-6.0, high=3.0, size=(61,)).astype(np.float32)[::-2]
-        min_val, max_val = numpy_minmax.minmax(arr)
-        assert min_val == np.amin(arr)
-        assert max_val == np.amax(arr)
+def test_minmax_float64_numpy_fallback():
+    arr = np.arange(17, dtype=np.float64)
+    min_val, max_val = numpy_minmax.minmax(arr)
+    assert min_val == 0.0
+    assert max_val == 16.0
+    assert isinstance(min_val, np.float64)
+    assert isinstance(max_val, np.float64)
 
-    def test_minimax_1d_non_contiguous_negative_stride_increasing(self):
-        arr = np.arange(start = 17, step= -1, stop = -19, dtype=np.float32)[::-2]
-        min_val, max_val = numpy_minmax.minmax(arr)
-        assert min_val == np.amin(arr)
-        assert max_val == np.amax(arr)
 
-    def test_minimax_1d_non_contiguous_negative_stride_decreasing(self):
-        arr = np.arange(start = -21, stop = 13, dtype=np.float32)[::-2]
-        min_val, max_val = numpy_minmax.minmax(arr)
-        assert min_val == np.amin(arr)
-        assert max_val == np.amax(arr)
+@pytest.mark.parametrize("dtype", [np.float32, np.int16])
+def test_minmax_2d_small1(dtype):
+    np.random.seed(1)
+    arr = np.random.uniform(low=-6.0, high=3.0, size=(15, 2)).astype(dtype)
+    min_val, max_val = numpy_minmax.minmax(arr)
+    assert min_val == np.amin(arr)
+    assert max_val == np.amax(arr)
 
-    def test_minimax_1d_non_contiguous_negative_stride_short(self):
-        arr = np.random.uniform(low=-6.0, high=3.0, size=(27,)).astype(np.float32)[::-3]
-        min_val, max_val = numpy_minmax.minmax(arr)
-        assert min_val == np.amin(arr)
-        assert max_val == np.amax(arr)
 
-    def test_minmax_unaligned(self):
-        # Allocate memory and create an unaligned array from that
-        buf = np.arange(402, dtype=np.uint8)
-        arr = np.frombuffer(buf.data, offset=2, count=100, dtype=np.float32)
-        arr.shape = 10, 10
-        assert arr.flags["ALIGNED"] == False
+@pytest.mark.parametrize("dtype", [np.float32, np.int16])
+def test_minmax_2d_small2(dtype):
+    np.random.seed(2)
+    arr = np.random.uniform(low=-6.0, high=3.0, size=(2, 15)).astype(dtype)
+    min_val, max_val = numpy_minmax.minmax(arr)
+    assert min_val == np.amin(arr)
+    assert max_val == np.amax(arr)
 
-        min_val, max_val = numpy_minmax.minmax(arr)
-        assert min_val == np.amin(arr)
-        assert max_val == np.amax(arr)
 
-    def test_minmax_3d_shape(self):
-        arr = np.random.uniform(low=-6.0, high=3.0, size=(2, 2, 16)).astype(np.float32)
-        min_val, max_val = numpy_minmax.minmax(arr)
-        assert min_val == np.amin(arr)
-        assert max_val == np.amax(arr)
+@pytest.mark.parametrize("dtype", [np.float32, np.int16])
+def test_minmax_2d_shape_large(dtype):
+    np.random.seed(3)
+    arr = np.random.uniform(low=-6.0, high=3.0, size=(2, 999)).astype(dtype)
+    min_val, max_val = numpy_minmax.minmax(arr)
+    assert min_val == np.amin(arr)
+    assert max_val == np.amax(arr)
 
-    @pytest.mark.parametrize("shape", [(0,), (0, 0)])
-    def test_minmax_empty_array(self, shape):
-        arr = np.empty(shape=shape, dtype=np.float32)
-        with pytest.raises(ValueError):
-            numpy_minmax.minmax(arr)
+
+@pytest.mark.parametrize("dtype", [np.float32, np.int16])
+def test_minimax_2d_f_contiguous(dtype):
+    np.random.seed(4)
+    arr = np.random.uniform(low=-6.0, high=3.0, size=(2, 27)).astype(dtype)
+    arr = np.asfortranarray(arr)
+    min_val, max_val = numpy_minmax.minmax(arr)
+    assert min_val == np.amin(arr)
+    assert max_val == np.amax(arr)
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.int16])
+def test_minimax_1d_non_contiguous_short(dtype):
+    np.random.seed(5)
+    arr = np.random.uniform(low=-6.0, high=3.0, size=(27,)).astype(dtype)[::3]
+    min_val, max_val = numpy_minmax.minmax(arr)
+    assert min_val == np.amin(arr)
+    assert max_val == np.amax(arr)
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.int16])
+def test_minimax_1d_non_contiguous(dtype):
+    np.random.seed(6)
+    arr = np.random.uniform(low=-6.0, high=3.0, size=(27,)).astype(dtype)[::2]
+    min_val, max_val = numpy_minmax.minmax(arr)
+    assert min_val == np.amin(arr)
+    assert max_val == np.amax(arr)
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.int16])
+def test_minimax_1d_negative_stride(dtype):
+    np.random.seed(7)
+    arr = np.random.uniform(low=-6.0, high=3.0, size=(27,)).astype(dtype)[::-1]
+    min_val, max_val = numpy_minmax.minmax(arr)
+    assert min_val == np.amin(arr)
+    assert max_val == np.amax(arr)
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.int16])
+def test_minimax_1d_non_contiguous_negative_stride(dtype):
+    np.random.seed(7)
+    arr = np.random.uniform(low=-6.0, high=3.0, size=(61,)).astype(dtype)[::-2]
+    min_val, max_val = numpy_minmax.minmax(arr)
+    assert min_val == np.amin(arr)
+    assert max_val == np.amax(arr)
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.int16])
+def test_minimax_1d_non_contiguous_negative_stride_increasing(dtype):
+    np.random.seed(8)
+    arr = np.arange(start=17, step=-1, stop=-19, dtype=dtype)[::-2]
+    min_val, max_val = numpy_minmax.minmax(arr)
+    assert min_val == np.amin(arr)
+    assert max_val == np.amax(arr)
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.int16])
+def test_minimax_1d_non_contiguous_negative_stride_decreasing(dtype):
+    np.random.seed(9)
+    arr = np.arange(start=-21, stop=13, dtype=dtype)[::-2]
+    min_val, max_val = numpy_minmax.minmax(arr)
+    assert min_val == np.amin(arr)
+    assert max_val == np.amax(arr)
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.int16])
+def test_minimax_1d_non_contiguous_negative_stride_short(dtype):
+    np.random.seed(10)
+    arr = np.random.uniform(low=-6.0, high=3.0, size=(27,)).astype(dtype)[::-3]
+    min_val, max_val = numpy_minmax.minmax(arr)
+    assert min_val == np.amin(arr)
+    assert max_val == np.amax(arr)
+
+
+def test_minmax_unaligned():
+    # Allocate memory and create an unaligned array from that
+    buf = np.arange(402, dtype=np.uint8)
+    arr = np.frombuffer(buf.data, offset=2, count=100, dtype=np.float32)
+    arr.shape = 10, 10
+    assert arr.flags["ALIGNED"] == False
+
+    min_val, max_val = numpy_minmax.minmax(arr)
+    assert min_val == np.amin(arr)
+    assert max_val == np.amax(arr)
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.int16])
+def test_minmax_3d_shape(dtype):
+    arr = np.random.uniform(low=-6.0, high=3.0, size=(2, 2, 16)).astype(dtype)
+    min_val, max_val = numpy_minmax.minmax(arr)
+    assert min_val == np.amin(arr)
+    assert max_val == np.amax(arr)
+
+
+@pytest.mark.parametrize("shape", [(0,), (0, 0)])
+@pytest.mark.parametrize("dtype", [np.float32, np.int16])
+def test_minmax_empty_array(dtype, shape):
+    arr = np.empty(shape=shape, dtype=dtype)
+    with pytest.raises(ValueError):
+        numpy_minmax.minmax(arr)


### PR DESCRIPTION
And so the code duplication begins 🤪 

Right now, it supports
✔️ AVX
✔️ contiguous arrays

But not AVX512 and strided arrays

Close https://github.com/nomonosound/numpy-minmax/issues/27