### PR TITLE
Added support for numpy>=2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, ubuntu-22.04-arm64, macos-latest]
+        os: [ubuntu-latest, macos-latest]
+        arch: [x86_64, arm64]
         python-version: [3.9]
 
     if: startsWith(github.event.head_commit.message, 'Release') || github.event_name == 'workflow_dispatch'
@@ -28,7 +29,7 @@ jobs:
       - name: Build and test wheels
         env:
           CIBW_ARCHS: "auto64"
-          CIBW_SKIP: "cp36-* cp37-* pp37-* pp310-* cp313-*"
+          CIBW_SKIP: "cp36-* cp37-* cp38-* pp37-* pp38-* pp313-* cp313-*"
           CC: clang
         run: |
           python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         arch: [x86_64, arm64]
-        python-version: [3.11]
+        python-version: [3.9]
 
     if: startsWith(github.event.head_commit.message, 'Release') || github.event_name == 'workflow_dispatch'
     steps:
@@ -29,7 +29,7 @@ jobs:
       - name: Build and test wheels
         env:
           CIBW_ARCHS: "auto64"
-          CIBW_SKIP: "cp36-* cp37-* cp38-* pp37-* pp38-* pp313-* cp313-*"
+          CIBW_SKIP: "cp36-* cp37-* cp38-* pp37-* pp38-* pp313-* cp313-* *-musllinux_x86_64"
           CC: clang
         run: |
           python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         arch: [x86_64, arm64]
-        python-version: [3.9]
+        python-version: [3.11]
 
     if: startsWith(github.event.head_commit.message, 'Release') || github.event_name == 'workflow_dispatch'
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,4 @@ cython_debug/
 
 # Dynamically generated version file
 numpy_minmax/_version.py
+.qodo

--- a/.gitignore
+++ b/.gitignore
@@ -161,4 +161,3 @@ cython_debug/
 
 # Dynamically generated version file
 numpy_minmax/_version.py
-.qodo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.3.1"
 description = "A fast python library for finding both min and max value in a NumPy array"
 dependencies = [
     "cffi>=1.0.0",
-    "numpy>=1.21,<2"
+    "numpy>=1.21"
 ]
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
This addresses issue https://github.com/nomonosound/numpy-minmax/issues/26.

All unit tests pass. Compatibility with numpy>=1.21 is maintained