### PR TITLE
Fix SIGILL on CPUs without AVX-512 support

### DIFF
--- a/numpy_minmax/_minmax.c
+++ b/numpy_minmax/_minmax.c
@@ -153,7 +153,7 @@ minmax_result_float32 minmax_avx_float32(const float *a, size_t length) {
     return reduce_result_from_mm256_float32(min_vals, max_vals, result);
 }
 
-static inline minmax_result_float32 reduce_result_from_mm512_float32(__m512 min_vals, __m512 max_vals, minmax_result_float32 result) {
+__attribute__((target("avx512f"))) static inline minmax_result_float32 reduce_result_from_mm512_float32(__m512 min_vals, __m512 max_vals, minmax_result_float32 result) {
     float temp_min[16], temp_max[16];
     _mm512_storeu_ps(temp_min, min_vals);
     _mm512_storeu_ps(temp_max, max_vals);
@@ -164,7 +164,7 @@ static inline minmax_result_float32 reduce_result_from_mm512_float32(__m512 min_
     return result;
 }
 
-minmax_result_float32 minmax_avx512_float32(const float *a, size_t length) {
+__attribute__((target("avx512f"))) minmax_result_float32 minmax_avx512_float32(const float *a, size_t length) {
     minmax_result_float32 result = { .min_val = FLT_MAX, .max_val = -FLT_MAX };
 
     __m512 min_vals = _mm512_loadu_ps(a);

--- a/numpy_minmax/_minmax_cffi.py
+++ b/numpy_minmax/_minmax_cffi.py
@@ -31,8 +31,7 @@ if os.name == "posix":
 
 # Detect architecture and set appropriate SIMD-related compile args
 if platform.machine().lower() in ["x86_64", "amd64", "i386", "i686"]:
-    extra_compile_args.append("-mavx")
-    extra_compile_args.append("-mavx512f")
+    extra_compile_args.append("-mavx2")
 
 ffibuilder.set_source("_numpy_minmax", c_code, extra_compile_args=extra_compile_args)
 


### PR DESCRIPTION
[Full disclosure: I made this change using Claude Code, I hope that's okay]

The build system passed -mavx512f globally for all x86_64 targets, causing the compiler to auto-vectorize the entire shared library with AVX-512 instructions. This produced SIGILL on CPUs that only support AVX2, as the crash occurred during module initialisation before the runtime cpuid check could gate the AVX-512 code path.

Fix by replacing -mavx and -mavx512f with -mavx2 in the global compile flags, and adding __attribute__((target("avx512f"))) to the two AVX-512 functions so they are still compiled with AVX-512 codegen.